### PR TITLE
[Feat]: add aria-label, title, rel for social anchors on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,16 +912,16 @@
                 <p>Intrinsicly matrix high standards in niches whereas intermandated niche markets. Objectively harness competitive resources.</p>
                 <ul class="list-unstyled social-list mb-0">
                   <li class="list-inline-item">
-                    <a href="#" class="rounded"><span class="ti-facebook white-bg color-2 shadow rounded-circle"></span></a>
+                    <a href="#" class="rounded" aria-label="Visit us on Facebook" title="Facebook (External Link)" rel=”noopener noreferrer”><span class="ti-facebook white-bg color-2 shadow rounded-circle"></span></a>
                   </li>
                   <li class="list-inline-item">
-                    <a href="#" class="rounded"><span class="ti-twitter white-bg color-2 shadow rounded-circle"></span></a>
+                    <a href="#" class="rounded" aria-label="Visit us on Twitter" title="Twitter (External Link)" rel=”noopener noreferrer”><span class="ti-twitter white-bg color-2 shadow rounded-circle"></span></a>
                   </li>
                   <li class="list-inline-item">
-                    <a href="#" class="rounded"><span class="ti-linkedin white-bg color-2 shadow rounded-circle"></span></a>
+                    <a href="#" class="rounded" aria-label="Visit us on Linkedin" title="Linkedin (External Link)" rel=”noopener noreferrer”><span class="ti-linkedin white-bg color-2 shadow rounded-circle"></span></a>
                   </li>
                   <li class="list-inline-item">
-                    <a href="#" class="rounded"><span class="ti-dribbble white-bg color-2 shadow rounded-circle"></span></a>
+                    <a href="#" class="rounded" aria-label="Visit us on Dribble" title="Dribble (External Link)" rel=”noopener noreferrer”><span class="ti-dribbble white-bg color-2 shadow rounded-circle"></span></a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
## Related Issue(s)
- This PR Closes/Fixes: #65 

## Proposed Changes
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Added `title` attribute, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Type of Change

- [x] New Feature (Landing Page)
- [ ] New Feature (App)
- [ ] Bug (Landing Page)
- [ ] Bug (App)
- [ ] New Component (App)
- [ ] Enhancement
- [ ] Documentation / ReadMe / Workflows
- Other (If not in above options):  

## Your Idea for Level (GSSoC)

- [ ] Level 1
- [x] Level 2
- [ ] Level 3


## Screenshots (if applicable)

- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people